### PR TITLE
Update streamers socials

### DIFF
--- a/app/app/package.json
+++ b/app/app/package.json
@@ -28,6 +28,7 @@
     "@astrojs/starlight-tailwind": "^4.0.1",
     "@iconify-json/ic": "^1.2.2",
     "@iconify-json/mdi": "^1.2.3",
+    "@iconify-json/ri": "^1.2.5",
     "@iconify-json/twemoji": "^1.2.2",
     "@iconify/tailwind4": "^1.0.6",
     "@tailwindcss/vite": "^4.1.8",

--- a/app/app/pnpm-lock.yaml
+++ b/app/app/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@iconify-json/mdi':
         specifier: ^1.2.3
         version: 1.2.3
+      '@iconify-json/ri':
+        specifier: ^1.2.5
+        version: 1.2.5
       '@iconify-json/twemoji':
         specifier: ^1.2.2
         version: 1.2.2
@@ -341,6 +344,9 @@ packages:
 
   '@iconify-json/mdi@1.2.3':
     resolution: {integrity: sha512-O3cLwbDOK7NNDf2ihaQOH5F9JglnulNDFV7WprU2dSoZu3h3cWH//h74uQAB87brHmvFVxIOkuBX2sZSzYhScg==}
+
+  '@iconify-json/ri@1.2.5':
+    resolution: {integrity: sha512-kWGimOXMZrlYusjBKKXYOWcKhbOHusFsmrmRGmjS7rH0BpML5A9/fy8KHZqFOwZfC4M6amObQYbh8BqO5cMC3w==}
 
   '@iconify-json/twemoji@1.2.2':
     resolution: {integrity: sha512-ckWEY5KhIQgdFd9VGvfhecTtYUx3ihXycwlZcEws87LxuvIThMHNBCblrQQ5afhbGMfg21dF+z9F+ODMRDYHMg==}
@@ -2873,6 +2879,10 @@ snapshots:
       '@iconify/types': 2.0.0
 
   '@iconify-json/mdi@1.2.3':
+    dependencies:
+      '@iconify/types': 2.0.0
+
+  '@iconify-json/ri@1.2.5':
     dependencies:
       '@iconify/types': 2.0.0
 

--- a/app/app/src/components/CountryFlag.astro
+++ b/app/app/src/components/CountryFlag.astro
@@ -17,32 +17,20 @@ function parseCountryCode(code: any): string | undefined
 	return typeof code === 'string' ? code.toUpperCase() : code
 }
 
-const countryCode: CountryCode | undefined = parseCountryCode(Astro.props.country) as any
+const cc: CountryCode | undefined = parseCountryCode(Astro.props.country) as any
 ---
 
 {
-	countryCode === 'AUS'
-		? <span class="icon-[twemoji--flag-australia] icon-align icon-fw"></span>
-	: countryCode === 'BEL'
-		? <span class="icon-[twemoji--flag-belgium] icon-align icon-fw"></span>
-	: countryCode === 'CAN'
-		? <span class="icon-[twemoji--flag-canada] icon-align icon-fw"></span>
-	: countryCode === 'CHE'
-		? <span class="icon-[twemoji--flag-switzerland] icon-align icon-fw"></span>
-	: countryCode === 'ESP'
-		? <span class="icon-[twemoji--flag-spain] icon-align icon-fw"></span>
-	: countryCode === 'FRA'
-		? <span class="icon-[twemoji--flag-france] icon-align icon-fw"></span>
-	: countryCode === 'GBR'
-		? <span class="icon-[twemoji--flag-united-kingdom] icon-align icon-fw"></span>
-	: countryCode === 'IDN'
-		? <span class="icon-[twemoji--flag-indonesia] icon-align icon-fw"></span>
-	: countryCode === 'ITA'
-		? <span class="icon-[twemoji--flag-italy] icon-align icon-fw"></span>
-	: countryCode === 'SGP'
-		? <span class="icon-[twemoji--flag-singapore] icon-align icon-fw"></span>
-	: countryCode === 'USA'
-		? <span class="icon-[twemoji--flag-united-states] icon-align icon-fw"></span>
-	:
-		<em>{countryCode}</em>
+	cc === 'AUS' ? <span class="icon-[twemoji--flag-australia] icon-align icon-fw"></span>
+	: cc === 'BEL' ? <span class="icon-[twemoji--flag-belgium] icon-align icon-fw"></span>
+	: cc === 'CAN' ? <span class="icon-[twemoji--flag-canada] icon-align icon-fw"></span>
+	: cc === 'CHE' ? <span class="icon-[twemoji--flag-switzerland] icon-align icon-fw"></span>
+	: cc === 'ESP' ? <span class="icon-[twemoji--flag-spain] icon-align icon-fw"></span>
+	: cc === 'FRA' ? <span class="icon-[twemoji--flag-france] icon-align icon-fw"></span>
+	: cc === 'GBR' ? <span class="icon-[twemoji--flag-united-kingdom] icon-align icon-fw"></span>
+	: cc === 'IDN' ? <span class="icon-[twemoji--flag-indonesia] icon-align icon-fw"></span>
+	: cc === 'ITA' ? <span class="icon-[twemoji--flag-italy] icon-align icon-fw"></span>
+	: cc === 'SGP' ? <span class="icon-[twemoji--flag-singapore] icon-align icon-fw"></span>
+	: cc === 'USA' ? <span class="icon-[twemoji--flag-united-states] icon-align icon-fw"></span>
+	: <em>{cc}</em>
 }

--- a/app/app/src/components/CountryFlag.astro
+++ b/app/app/src/components/CountryFlag.astro
@@ -9,6 +9,7 @@ type CountryCode =
 	| 'GBR' // United Kingdom
 	| 'IDN' // Indonesia
 	| 'ITA' // Italy
+	| 'SGP' // Singapore
 	| 'USA' // United States
 
 function parseCountryCode(code: any): string | undefined
@@ -20,26 +21,28 @@ const countryCode: CountryCode | undefined = parseCountryCode(Astro.props.countr
 ---
 
 {
-countryCode === 'AUS'
-	? <span class="icon-[twemoji--flag-australia] icon-align icon-fw"></span>
-: countryCode === 'BEL'
-	? <span class="icon-[twemoji--flag-belgium] icon-align icon-fw"></span>
-: countryCode === 'CAN'
-	? <span class="icon-[twemoji--flag-canada] icon-align icon-fw"></span>
-: countryCode === 'CHE'
-	? <span class="icon-[twemoji--flag-switzerland] icon-align icon-fw"></span>
-: countryCode === 'ESP'
-	? <span class="icon-[twemoji--flag-spain] icon-align icon-fw"></span>
-: countryCode === 'FRA'
-	? <span class="icon-[twemoji--flag-france] icon-align icon-fw"></span>
-: countryCode === 'GBR'
-	? <span class="icon-[twemoji--flag-united-kingdom] icon-align icon-fw"></span>
-: countryCode === 'IDN'
-	? <span class="icon-[twemoji--flag-indonesia] icon-align icon-fw"></span>
-: countryCode === 'ITA'
-	? <span class="icon-[twemoji--flag-italy] icon-align icon-fw"></span>
-: countryCode === 'USA'
-	? <span class="icon-[twemoji--flag-united-states] icon-align icon-fw"></span>
-:
-	<em>{countryCode}</em>
+	countryCode === 'AUS'
+		? <span class="icon-[twemoji--flag-australia] icon-align icon-fw"></span>
+	: countryCode === 'BEL'
+		? <span class="icon-[twemoji--flag-belgium] icon-align icon-fw"></span>
+	: countryCode === 'CAN'
+		? <span class="icon-[twemoji--flag-canada] icon-align icon-fw"></span>
+	: countryCode === 'CHE'
+		? <span class="icon-[twemoji--flag-switzerland] icon-align icon-fw"></span>
+	: countryCode === 'ESP'
+		? <span class="icon-[twemoji--flag-spain] icon-align icon-fw"></span>
+	: countryCode === 'FRA'
+		? <span class="icon-[twemoji--flag-france] icon-align icon-fw"></span>
+	: countryCode === 'GBR'
+		? <span class="icon-[twemoji--flag-united-kingdom] icon-align icon-fw"></span>
+	: countryCode === 'IDN'
+		? <span class="icon-[twemoji--flag-indonesia] icon-align icon-fw"></span>
+	: countryCode === 'ITA'
+		? <span class="icon-[twemoji--flag-italy] icon-align icon-fw"></span>
+	: countryCode === 'SGP'
+		? <span class="icon-[twemoji--flag-singapore] icon-align icon-fw"></span>
+	: countryCode === 'USA'
+		? <span class="icon-[twemoji--flag-united-states] icon-align icon-fw"></span>
+	:
+		<em>{countryCode}</em>
 }

--- a/app/app/src/components/SocialPlatformIcon.astro
+++ b/app/app/src/components/SocialPlatformIcon.astro
@@ -4,9 +4,12 @@ type SocialPlatform =
 	| 'bluesky' // Bluesky
 	| 'twitter' // Twitter
 	| 'mastodon' // Mastodon
+	| 'facebook' // Facebook
 	| 'youtube' // YouTube
 	| 'tiktok' // TikTok
 	| 'instagram' // Instagram
+	| 'telegram' // Telegram
+	| 'github' // GitHub
 	| 'website' // Website
 	| 'links' // Links
 
@@ -27,12 +30,18 @@ const socialPlatform: SocialPlatform | undefined = parseSocialPlatform(Astro.pro
 		? <span class="icon-[mdi--twitter] icon-align icon-fw"></span>
 	: socialPlatform === 'mastodon'
 		? <span class="icon-[mdi--mastodon] icon-align icon-fw"></span>
+	: socialPlatform === 'facebook'
+		? <span class="icon-[mdi--facebook] icon-align icon-fw"></span>
 	: socialPlatform === 'youtube'
 		? <span class="icon-[mdi--youtube] icon-align icon-fw"></span>
 	: socialPlatform === 'tiktok'
 		? <span class="icon-[ic--baseline-tiktok] icon-align icon-fw"></span>
 	: socialPlatform === 'instagram'
 		? <span class="icon-[mdi--instagram] icon-align icon-fw"></span>
+	: socialPlatform === 'telegram'
+		? <span class="icon-[mdi--telegram] icon-align icon-fw"></span>
+	: socialPlatform === 'github'
+		? <span class="icon-[mdi--github] icon-align icon-fw"></span>
 	: socialPlatform === 'website'
 		? <span class="icon-[mdi--web] icon-align icon-fw"></span>
 	: socialPlatform === 'links'

--- a/app/app/src/components/SocialPlatformIcon.astro
+++ b/app/app/src/components/SocialPlatformIcon.astro
@@ -9,6 +9,8 @@ type SocialPlatform =
 	| 'tiktok' // TikTok
 	| 'instagram' // Instagram
 	| 'telegram' // Telegram
+	| 'patreon' // Patreon
+	| 'tumblr' // Tumblr
 	| 'github' // GitHub
 	| 'website' // Website
 	| 'links' // Links
@@ -40,6 +42,10 @@ const socialPlatform: SocialPlatform | undefined = parseSocialPlatform(Astro.pro
 		? <span class="icon-[mdi--instagram] icon-align icon-fw"></span>
 	: socialPlatform === 'telegram'
 		? <span class="icon-[mdi--telegram] icon-align icon-fw"></span>
+	: socialPlatform === 'patreon'
+		? <span class="icon-[mdi--patreon] icon-align icon-fw"></span>
+	: socialPlatform === 'tumblr'
+		? <span class="icon-[mdi--tumblr] icon-align icon-fw"></span>
 	: socialPlatform === 'github'
 		? <span class="icon-[mdi--github] icon-align icon-fw"></span>
 	: socialPlatform === 'website'

--- a/app/app/src/components/SocialPlatformIcon.astro
+++ b/app/app/src/components/SocialPlatformIcon.astro
@@ -7,6 +7,8 @@ type SocialPlatform =
 	| 'youtube' // YouTube
 	| 'tiktok' // TikTok
 	| 'instagram' // Instagram
+	| 'website' // Website
+	| 'links' // Links
 
 function parseSocialPlatform(code: any): string | undefined
 {
@@ -31,6 +33,8 @@ const socialPlatform: SocialPlatform | undefined = parseSocialPlatform(Astro.pro
 		? <span class="icon-[ic--baseline-tiktok] icon-align icon-fw"></span>
 	: socialPlatform === 'instagram'
 		? <span class="icon-[mdi--instagram] icon-align icon-fw"></span>
+	: socialPlatform === 'website'
+		? <span class="icon-[mdi--web] icon-align icon-fw"></span>
 	: socialPlatform === 'links'
 		? <span class="icon-[mdi--link] icon-align icon-fw"></span>
 	:

--- a/app/app/src/components/SocialPlatformIcon.astro
+++ b/app/app/src/components/SocialPlatformIcon.astro
@@ -16,18 +16,18 @@ const socialPlatform: SocialPlatform | undefined = parseSocialPlatform(Astro.pro
 ---
 
 {
-socialPlatform === 'twitch'
-	? <span class="icon-[mdi--twitch] icon-align icon-fw"></span>
-: socialPlatform === 'bluesky'
-	? <span class="icon-[ri--bluesky-fill] icon-align icon-fw"></span>
-: socialPlatform === 'twitter'
-	? <span class="icon-[mdi--twitter] icon-align icon-fw"></span>
-: socialPlatform === 'youtube'
-	? <span class="icon-[mdi--youtube] icon-align icon-fw"></span>
-: socialPlatform === 'tiktok'
-	? <span class="icon-[ic--baseline-tiktok] icon-align icon-fw"></span>
-: socialPlatform === 'instagram'
-	? <span class="icon-[mdi--instagram] icon-align icon-fw"></span>
-:
-	<em>{socialPlatform}</em>
+	socialPlatform === 'twitch'
+		? <span class="icon-[mdi--twitch] icon-align icon-fw"></span>
+	: socialPlatform === 'bluesky'
+		? <span class="icon-[ri--bluesky-fill] icon-align icon-fw"></span>
+	: socialPlatform === 'twitter'
+		? <span class="icon-[mdi--twitter] icon-align icon-fw"></span>
+	: socialPlatform === 'youtube'
+		? <span class="icon-[mdi--youtube] icon-align icon-fw"></span>
+	: socialPlatform === 'tiktok'
+		? <span class="icon-[ic--baseline-tiktok] icon-align icon-fw"></span>
+	: socialPlatform === 'instagram'
+		? <span class="icon-[mdi--instagram] icon-align icon-fw"></span>
+	:
+		<em>{socialPlatform}</em>
 }

--- a/app/app/src/components/SocialPlatformIcon.astro
+++ b/app/app/src/components/SocialPlatformIcon.astro
@@ -1,57 +1,42 @@
 ---
 type SocialPlatform =
-	| 'twitch' // Twitch
 	| 'bluesky' // Bluesky
-	| 'twitter' // Twitter
-	| 'mastodon' // Mastodon
 	| 'facebook' // Facebook
-	| 'youtube' // YouTube
-	| 'tiktok' // TikTok
-	| 'instagram' // Instagram
-	| 'telegram' // Telegram
-	| 'patreon' // Patreon
-	| 'tumblr' // Tumblr
 	| 'github' // GitHub
-	| 'website' // Website
+	| 'instagram' // Instagram
 	| 'links' // Links
+	| 'mastodon' // Mastodon
+	| 'patreon' // Patreon
+	| 'telegram' // Telegram
+	| 'tiktok' // TikTok
+	| 'tumblr' // Tumblr
+	| 'twitch' // Twitch
+	| 'twitter' // Twitter
+	| 'website' // Website
+	| 'youtube' // YouTube
 
 function parseSocialPlatform(code: any): string | undefined
 {
 	return typeof code === 'string' ? code.toLowerCase() : code
 }
 
-const socialPlatform: SocialPlatform | undefined = parseSocialPlatform(Astro.props.platform) as any
+const sp: SocialPlatform | undefined = parseSocialPlatform(Astro.props.platform) as any
 ---
 
 {
-	socialPlatform === 'twitch'
-		? <span class="icon-[mdi--twitch] icon-align icon-fw"></span>
-	: socialPlatform === 'bluesky'
-		? <span class="icon-[ri--bluesky-fill] icon-align icon-fw"></span>
-	: socialPlatform === 'twitter'
-		? <span class="icon-[mdi--twitter] icon-align icon-fw"></span>
-	: socialPlatform === 'mastodon'
-		? <span class="icon-[mdi--mastodon] icon-align icon-fw"></span>
-	: socialPlatform === 'facebook'
-		? <span class="icon-[mdi--facebook] icon-align icon-fw"></span>
-	: socialPlatform === 'youtube'
-		? <span class="icon-[mdi--youtube] icon-align icon-fw"></span>
-	: socialPlatform === 'tiktok'
-		? <span class="icon-[ic--baseline-tiktok] icon-align icon-fw"></span>
-	: socialPlatform === 'instagram'
-		? <span class="icon-[mdi--instagram] icon-align icon-fw"></span>
-	: socialPlatform === 'telegram'
-		? <span class="icon-[mdi--telegram] icon-align icon-fw"></span>
-	: socialPlatform === 'patreon'
-		? <span class="icon-[mdi--patreon] icon-align icon-fw"></span>
-	: socialPlatform === 'tumblr'
-		? <span class="icon-[mdi--tumblr] icon-align icon-fw"></span>
-	: socialPlatform === 'github'
-		? <span class="icon-[mdi--github] icon-align icon-fw"></span>
-	: socialPlatform === 'website'
-		? <span class="icon-[mdi--web] icon-align icon-fw"></span>
-	: socialPlatform === 'links'
-		? <span class="icon-[mdi--link] icon-align icon-fw"></span>
-	:
-		<em>{socialPlatform}</em>
+	sp === 'bluesky' ? <span class="icon-[ri--bluesky-fill] icon-align icon-fw"></span>
+	: sp === 'facebook' ? <span class="icon-[mdi--facebook] icon-align icon-fw"></span>
+	: sp === 'github' ? <span class="icon-[mdi--github] icon-align icon-fw"></span>
+	: sp === 'instagram' ? <span class="icon-[mdi--instagram] icon-align icon-fw"></span>
+	: sp === 'links' ? <span class="icon-[mdi--link] icon-align icon-fw"></span>
+	: sp === 'mastodon' ? <span class="icon-[mdi--mastodon] icon-align icon-fw"></span>
+	: sp === 'patreon' ? <span class="icon-[mdi--patreon] icon-align icon-fw"></span>
+	: sp === 'telegram' ? <span class="icon-[mdi--telegram] icon-align icon-fw"></span>
+	: sp === 'tiktok' ? <span class="icon-[ic--baseline-tiktok] icon-align icon-fw"></span>
+	: sp === 'tumblr' ? <span class="icon-[mdi--tumblr] icon-align icon-fw"></span>
+	: sp === 'twitch' ? <span class="icon-[mdi--twitch] icon-align icon-fw"></span>
+	: sp === 'twitter' ? <span class="icon-[mdi--twitter] icon-align icon-fw"></span>
+	: sp === 'website' ? <span class="icon-[mdi--web] icon-align icon-fw"></span>
+	: sp === 'youtube' ? <span class="icon-[mdi--youtube] icon-align icon-fw"></span>
+	: <em>{sp}</em>
 }

--- a/app/app/src/components/SocialPlatformIcon.astro
+++ b/app/app/src/components/SocialPlatformIcon.astro
@@ -1,6 +1,7 @@
 ---
 type SocialPlatform =
 	| 'twitch' // Twitch
+	| 'bluesky' // Bluesky
 	| 'twitter' // Twitter
 	| 'youtube' // YouTube
 	| 'tiktok' // TikTok
@@ -17,6 +18,8 @@ const socialPlatform: SocialPlatform | undefined = parseSocialPlatform(Astro.pro
 {
 socialPlatform === 'twitch'
 	? <span class="icon-[mdi--twitch] icon-align icon-fw"></span>
+: socialPlatform === 'bluesky'
+	? <span class="icon-[ri--bluesky-fill] icon-align icon-fw"></span>
 : socialPlatform === 'twitter'
 	? <span class="icon-[mdi--twitter] icon-align icon-fw"></span>
 : socialPlatform === 'youtube'

--- a/app/app/src/components/SocialPlatformIcon.astro
+++ b/app/app/src/components/SocialPlatformIcon.astro
@@ -31,6 +31,8 @@ const socialPlatform: SocialPlatform | undefined = parseSocialPlatform(Astro.pro
 		? <span class="icon-[ic--baseline-tiktok] icon-align icon-fw"></span>
 	: socialPlatform === 'instagram'
 		? <span class="icon-[mdi--instagram] icon-align icon-fw"></span>
+	: socialPlatform === 'links'
+		? <span class="icon-[mdi--link] icon-align icon-fw"></span>
 	:
 		<em>{socialPlatform}</em>
 }

--- a/app/app/src/components/SocialPlatformIcon.astro
+++ b/app/app/src/components/SocialPlatformIcon.astro
@@ -3,6 +3,7 @@ type SocialPlatform =
 	| 'twitch' // Twitch
 	| 'bluesky' // Bluesky
 	| 'twitter' // Twitter
+	| 'mastodon' // Mastodon
 	| 'youtube' // YouTube
 	| 'tiktok' // TikTok
 	| 'instagram' // Instagram
@@ -22,6 +23,8 @@ const socialPlatform: SocialPlatform | undefined = parseSocialPlatform(Astro.pro
 		? <span class="icon-[ri--bluesky-fill] icon-align icon-fw"></span>
 	: socialPlatform === 'twitter'
 		? <span class="icon-[mdi--twitter] icon-align icon-fw"></span>
+	: socialPlatform === 'mastodon'
+		? <span class="icon-[mdi--mastodon] icon-align icon-fw"></span>
 	: socialPlatform === 'youtube'
 		? <span class="icon-[mdi--youtube] icon-align icon-fw"></span>
 	: socialPlatform === 'tiktok'

--- a/app/app/src/components/StreamersTable.astro
+++ b/app/app/src/components/StreamersTable.astro
@@ -1,12 +1,22 @@
 ---
-import { record } from 'astro:schema'
 import YAML from 'yaml'
 
 import CountryFlag from '~/components/CountryFlag.astro'
 import SocialPlatformIcon from '~/components/SocialPlatformIcon.astro'
 import streamersSocialsYml from '~/data/streamers/socials.yml?raw'
 
-interface StreamerSocials {
+interface YamlStreamerSocials
+{
+	name: string
+	country: string
+	socials: Array<{
+		platform: string
+		url: string
+	}> | null
+}
+
+interface StreamerSocials
+{
 	name: string
 	country: string
 	socials: Array<{
@@ -17,23 +27,32 @@ interface StreamerSocials {
 
 const { streamersListYml = '[]' } = Astro.props
 const streamersList = YAML.parse(streamersListYml) as Array<string>
-const streamersSocials = YAML.parse(streamersSocialsYml) as Record<string, StreamerSocials>
+const streamersSocials = YAML.parse(streamersSocialsYml) as Record<string, YamlStreamerSocials>
 
 const streamers: Array<StreamerSocials> = streamersList.map(
-	(name) =>
+	(name): StreamerSocials =>
 	{
 		const streamer = streamersSocials[name]
 
 		if (!streamer)
 		{
-			return { name, country: '?', socials: [] }
+			return {
+				name: name,
+				country: '?',
+				socials: [],
+			}
 		}
 
-		streamer.socials = streamer.socials.filter(
-			(social) => social.platform && social.url
-		)
-
-		return streamer
+		return {
+			name: streamer.name,
+			country: streamer.country,
+			socials: (streamer.socials || []).map(
+				(social) => ({
+					platform: social.platform.toLowerCase(),
+					url: social.url
+				})
+			)
+		}
 	}
 )
 ---

--- a/app/app/src/components/StreamersTable.astro
+++ b/app/app/src/components/StreamersTable.astro
@@ -29,6 +29,16 @@ const { streamersListYml = '[]' } = Astro.props
 const streamersList = YAML.parse(streamersListYml) as Array<string>
 const streamersSocials = YAML.parse(streamersSocialsYml) as Record<string, YamlStreamerSocials>
 
+const socialPlatforms = [
+	'twitch',
+	'bluesky',
+	'twitter',
+	'youtube',
+	'tiktok',
+	'website',
+	'links',
+]
+
 const streamers: Array<StreamerSocials> = streamersList.map(
 	(name): StreamerSocials =>
 	{
@@ -46,11 +56,21 @@ const streamers: Array<StreamerSocials> = streamersList.map(
 		return {
 			name: streamer.name,
 			country: streamer.country,
-			socials: (streamer.socials || []).map(
-				(social) => ({
-					platform: social.platform.toLowerCase(),
-					url: social.url
-				})
+			socials: socialPlatforms.reduce(
+				(socials, platform) =>
+				{
+					const social = streamer.socials?.find(
+						(s) => s.platform.toLowerCase() === platform
+					)
+
+					if (social)
+					{
+						socials.push(social)
+					}
+
+					return socials
+				},
+				[] as StreamerSocials['socials'],
 			)
 		}
 	}

--- a/app/app/src/components/StreamersTable.astro
+++ b/app/app/src/components/StreamersTable.astro
@@ -1,4 +1,5 @@
 ---
+import { record } from 'astro:schema'
 import YAML from 'yaml'
 
 import CountryFlag from '~/components/CountryFlag.astro'
@@ -19,7 +20,21 @@ const streamersList = YAML.parse(streamersListYml) as Array<string>
 const streamersSocials = YAML.parse(streamersSocialsYml) as Record<string, StreamerSocials>
 
 const streamers: Array<StreamerSocials> = streamersList.map(
-	(name) => streamersSocials[name] || { name, country: '?', socials: [] }
+	(name) =>
+	{
+		const streamer = streamersSocials[name]
+
+		if (!streamer)
+		{
+			return { name, country: '?', socials: [] }
+		}
+
+		streamer.socials = streamer.socials.filter(
+			(social) => social.platform && social.url
+		)
+
+		return streamer
+	}
 )
 ---
 
@@ -41,7 +56,7 @@ const streamers: Array<StreamerSocials> = streamersList.map(
 				</td>
 				<td>{streamer.name}</td>
 				<td>
-					{streamer.socials?.map((social, index) => (
+					{streamer.socials.map((social, index) => (
 						<>
 							<a href={social.url} target="_blank" rel="noopener noreferrer">{
 								}<SocialPlatformIcon platform={social.platform} />{

--- a/app/app/src/content/docs/fluff-event-2025/index.md
+++ b/app/app/src/content/docs/fluff-event-2025/index.md
@@ -10,11 +10,11 @@ L'événement vise à collecter des fonds pour l'association
 [**En Avant Toute(s)**](https://enavanttoutes.fr/), qui lutte pour l'égalité de genre et la fin des
 violences sexistes et sexuelles.
 
-Plusieurs participants de nationalités différentes ont participé à cet événement et engagé leurs
-spectateurs pour cette cause !
+**51 participants** de nationalités différentes ont participé pour engager leur communauté dans cet
+événement de **54 heures**, qui a permis de récolter **32 077 €** pour l'association soutenue.
 
-Les fonds sont récoltés grâce aux dons des spectateurs et aux bénéfices des ventes de produits
-dérivés sur la boutique en ligne exclusive de l'événement.
+Les fonds sont récoltés grâce aux dons directs des spectateurs et aux bénéfices issus des ventes de
+produits dérivés sur la boutique en ligne de l'événement.
 
 
 #### Activités

--- a/app/app/src/content/docs/fluff-event-2025/streamers.mdx
+++ b/app/app/src/content/docs/fluff-event-2025/streamers.mdx
@@ -5,7 +5,7 @@ title: Participants au Fluff Event 2025
 De nombreux streamers et créateurs de contenu ont participé au Fluff Event 2025, son marathon de
 streaming et la collecte de fonds pour l'association **En Avant Toute(s)**.
 
-**50 participants** de nationalités différentes ont participé à l'événement :
+**51 participants** de nationalités différentes ont participé à l'événement :
 
 import StreamersTable from '~/components/StreamersTable.astro'
 import streamersListYml from '~/data/streamers/2025.yml?raw'

--- a/app/app/src/data/streamers/2025.yml
+++ b/app/app/src/data/streamers/2025.yml
@@ -3,6 +3,7 @@
 - azeleneuf
 - baphostv
 - blakeprod
+- blaqkcat
 - dodgerakame
 - drakelelionblanc
 - elzbietatv

--- a/app/app/src/data/streamers/socials.yml
+++ b/app/app/src/data/streamers/socials.yml
@@ -449,6 +449,19 @@ blakeprod:
     - platform: Twitch
       url: https://www.twitch.tv/blakeprod
 
+blaqkcat:
+  name: BlaqkCat
+  country: USA
+  socials:
+    - platform: Twitch
+      url: https://www.twitch.tv/blaqkcat
+    - platform: Bluesky
+      url: https://blaqkcat.bsky.social/
+    - platform: Twitter
+      url: https://twitter.com/blaqkcat_
+    - platform: TikTok
+      url: https://www.tiktok.com/@blaqkcat
+
 dodgerakame:
   name: DodgerAkame
   country: '?'

--- a/app/app/src/data/streamers/socials.yml
+++ b/app/app/src/data/streamers/socials.yml
@@ -378,8 +378,16 @@ azeleneuf:
 
 bluedragon:
   name: BlueDragon
-  country: '?'
+  country: FRA
   socials:
+    - platform: Twitch
+      url: https://www.twitch.tv/bluedragonfr_
+    - platform: Twitter
+      url: https://twitter.com/BlueDragonFr
+    - platform: TikTok
+      url: https://www.tiktok.com/@bluedragonfr
+    - platform: YouTube
+      url: https://www.youtube.com/BlueDragonFr
 
 drakelelionblanc:
   name: DrakeLeLionBlanc
@@ -387,27 +395,55 @@ drakelelionblanc:
   socials:
     - platform: Twitch
       url: https://www.twitch.tv/drakelelionblanc
+    - platform: Bluesky
+      url: https://bsky.app/profile/drakelelionblanc.bsky.social
+    - platform: Twitter
+      url: https://twitter.com/DrakeLionBlanc
+    - platform: YouTube
+      url: https://www.youtube.com/channel/UCxEhUFS_YKodlF3YgqX4Mmg
 
 kekeflipnote:
   name: KekeFlipnote
-  country: '?'
+  country: FRA
   socials:
     - platform: Twitch
       url: https://www.twitch.tv/kekeflipnote
+    - platform: Twitter
+      url: https://x.com/KekeFlipnote
+    - platform: Patreon
+      url: https://www.patreon.com/k_eke
+    - platform: YouTube
+      url: https://www.youtube.com/channel/UCNdNkUfhFfzBtKRU_5QgUvw
+    - platform: Tumblr
+      url: https://k-eke.tumblr.com/
 
 kuroemberos:
-  name: KuroEmberos
+  name: Kuro Emberos
   country: '?'
   socials:
     - platform: Twitch
       url: https://www.twitch.tv/kuroemberos
+    - platform: Twitter
+      url: https://twitter.com/EmberosKuro
+    - platform: TikTok
+      url: https://www.tiktok.com/@kuroemberosvtuber
+    - platform: YouTube
+      url: https://www.youtube.com/channel/UC98Lm-r7jfRHtypAbRFCkeQ
 
 niphoyote:
-  name: Niphoyote
-  country: '?'
+  name: NiphoYote
+  country: ESP
   socials:
     - platform: Twitch
       url: https://www.twitch.tv/niphoyote
+    - platform: Bluesky
+      url: https://bsky.app/profile/nipho.bsky.social
+    - platform: Twitter
+      url: https://twitter.com/NiphoYote
+    - platform: YouTube
+      url: https://www.youtube.com/@NiphoYote
+    - platform: Telegram
+      url: https://t.me/+4RLzrQpzjCBhZjE0
 
 nyhgault:
   name: NyhGault
@@ -417,9 +453,15 @@ nyhgault:
       url: https://www.twitch.tv/nyhgault
 
 solva:
-  name: Solva
+  name: Catboat
   country: '?'
   socials:
+    - platform: Twitch
+      url: https://www.twitch.tv/catboat
+    - platform: YouTube
+      url: https://www.youtube.com/@catboatandrot
+    - platform: TikTok
+      url: https://www.tiktok.com/@catboatandrot/
 
 yaztalis:
   name: Yaztalis
@@ -427,6 +469,12 @@ yaztalis:
   socials:
     - platform: Twitch
       url: https://www.twitch.tv/yaztalis
+    - platform: Bluesky
+      url: https://bsky.app/profile/yaztalis.bsky.social
+    - platform: Twitter
+      url: https://twitter.com/Yaztalis
+    - platform: YouTube
+      url: https://www.youtube.com/@yaztalis
 
 amiliavt:
   name: AmiliaVT
@@ -434,6 +482,12 @@ amiliavt:
   socials:
     - platform: Twitch
       url: https://www.twitch.tv/amiliavt
+    - platform: Twitter
+      url: https://twitter.com/AmiliaVT
+    - platform: TikTok
+      url: https://www.tiktok.com/@amiliavt
+    - platform: Instagram
+      url: https://www.instagram.com/amiliavt/
 
 baphostv:
   name: Bapho
@@ -441,13 +495,23 @@ baphostv:
   socials:
     - platform: Twitch
       url: https://www.twitch.tv/baphostv
+    - platform: Twitter
+      url: https://twitter.com/BaphosTV
+    - platform: YouTube
+      url: https://www.youtube.com/@BaphosTV
+    - platform: TikTok
+      url: https://www.tiktok.com/@baphostv
 
 blakeprod:
   name: BlakeProd
-  country: '?'
+  country: CAN
   socials:
     - platform: Twitch
       url: https://www.twitch.tv/blakeprod
+    - platform: Bluesky
+      url: https://bsky.app/profile/protoblake.bsky.social
+    - platform: Twitter
+      url: https://twitter.com/ProtoBlake
 
 blaqkcat:
   name: BlaqkCat
@@ -464,24 +528,38 @@ blaqkcat:
 
 dodgerakame:
   name: DodgerAkame
-  country: '?'
+  country: FRA
   socials:
     - platform: Twitch
       url: https://www.twitch.tv/dodgerakame
+    - platform: Bluesky
+      url: https://bsky.app/profile/dodgerakame.bsky.social
+    - platform: Mastodon
+      url: https://meow.social/web/@DodgerAkame
+    - platform: YouTube
+      url: https://www.youtube.com/@DodgerAkame
+    - platform: TikTok
+      url: https://www.tiktok.com/@dodgerakame_twitch
 
 elzbietatv:
   name: ElzBietaTV
-  country: '?'
+  country: FRA
   socials:
     - platform: Twitch
       url: https://www.twitch.tv/elzbietatv
+    - platform: YouTube
+      url: https://www.youtube.com/channel/UCdmUHFiiALX0ofz5x9f6qKA
 
 emarcanine:
   name: Emarcanine
-  country: '?'
+  country: FRA
   socials:
     - platform: Twitch
       url: https://www.twitch.tv/emarcanine
+    - platform: Twitter
+      url: https://twitter.com/EmArcanine
+    - platform: TikTok
+      url: https://www.tiktok.com/@emarcanine
 
 endoku_chan:
   name: Endoku_Chan
@@ -489,20 +567,34 @@ endoku_chan:
   socials:
     - platform: Twitch
       url: https://www.twitch.tv/endoku_chan
+    - platform: Twitter
+      url: https://twitter.com/Endoku_chan
+    - platform: YouTube
+      url: https://www.youtube.com/channel/UCNsr4i807k8jbibJmAOiQxA
+    - platform: TikTok
+      url: https://www.tiktok.com/@endoku
 
 esliane:
   name: Esliane
-  country: '?'
+  country: FRA
   socials:
     - platform: Twitch
       url: https://www.twitch.tv/esliane
+    - platform: Twitter
+      url: https://twitter.com/Esliane_
+    - platform: TikTok
+      url: https://www.tiktok.com/@esliane_vt
+    - platform: Instagram
+      url: https://www.instagram.com/esliane_vt/
 
 extranumby:
   name: ExtraNumby
-  country: '?'
+  country: FRA
   socials:
     - platform: Twitch
       url: https://www.twitch.tv/extranumby
+    - platform: Instagram
+      url: https://www.instagram.com/extranumby/?next=%2F
 
 foxyareku:
   name: FoxyAreku
@@ -510,6 +602,12 @@ foxyareku:
   socials:
     - platform: Twitch
       url: https://www.twitch.tv/foxyareku
+    - platform: Bluesky
+      url: https://bsky.app/profile/foxyareku.live
+    - platform: YouTube
+      url: https://www.youtube.com/channel/UCCCkUCDYs1X2M_tkDgzKbXQ
+    - platform: TikTok
+      url: https://www.tiktok.com/@foxyareku
 
 hildamist:
   name: HildaMist
@@ -517,6 +615,10 @@ hildamist:
   socials:
     - platform: Twitch
       url: https://www.twitch.tv/hildamist
+    - platform: Bluesky
+      url: https://bsky.app/profile/hildamist.vtubers.social
+    - platform: TikTok
+      url: https://www.tiktok.com/@hildamist
 
 ikutokami:
   name: IkutoKami
@@ -524,13 +626,25 @@ ikutokami:
   socials:
     - platform: Twitch
       url: https://www.twitch.tv/ikutokami
+    - platform: Twitter
+      url: https://twitter.com/Ikuto_Kami
+    - platform: YouTube
+      url: https://www.youtube.com/@ikutokami3980
+    - platform: TikTok
+      url: https://www.tiktok.com/@ikutokami
 
 keola:
   name: Keola
-  country: '?'
+  country: FRA
   socials:
     - platform: Twitch
       url: https://www.twitch.tv/keola
+    - platform: Twitter
+      url: https://twitter.com/KeolaKumaneko
+    - platform: YouTube
+      url: https://www.youtube.com/channel/UC3kt7D6IBIv16ije97tmzSw
+    - platform: TikTok
+      url: https://www.tiktok.com/@keolakumaneko
 
 kokore:
   name: Kokore
@@ -538,13 +652,23 @@ kokore:
   socials:
     - platform: Twitch
       url: https://www.twitch.tv/kokore
+    - platform: Bluesky
+      url: https://bsky.app/profile/kokore.bsky.social
+    - platform: YouTube
+      url: https://www.youtube.com/channel/UCFUXlFPIgYGmsDOXrlQLwWA?view_as=subscriber
+    - platform: Instagram
+      url: https://www.instagram.com/kokore_42
 
 lechatoo:
   name: LeChatoo
-  country: '?'
+  country: CAN
   socials:
     - platform: Twitch
       url: https://www.twitch.tv/lechatoo
+    - platform: Twitter
+      url: https://twitter.com/LeChatsake
+    - platform: TikTok
+      url: https://www.tiktok.com/@lechatoo
 
 lutzthakitten:
   name: LutzThaKitten
@@ -552,6 +676,10 @@ lutzthakitten:
   socials:
     - platform: Twitch
       url: https://www.twitch.tv/lutzthakitten
+    # - platform: Twitter
+    #   url: https://twitter.com/ImLutz_
+    - platform: YouTube
+      url: https://www.youtube.com/channel/UC9unFdhEH8vAHG_cfugrv2Q
 
 malidoudou:
   name: MaliDoudou
@@ -559,6 +687,14 @@ malidoudou:
   socials:
     - platform: Twitch
       url: https://www.twitch.tv/malidoudou
+    - platform: Bluesky
+      url: https://bsky.app/profile/malidoudou.vtubers.social
+    - platform: Twitter
+      url: https://x.com/Malidoudou_
+    - platform: YouTube
+      url: https://www.youtube.com/channel/UCGrjbPyrpnNKNrIIfIjzXIw
+    - platform: Instagram
+      url: https://www.instagram.com/malidoudou_twitch/?hl=fr
 
 manaryuujin:
   name: ManaRyuuJin
@@ -566,13 +702,25 @@ manaryuujin:
   socials:
     - platform: Twitch
       url: https://www.twitch.tv/manaryuujin
+    - platform: Twitter
+      url: https://twitter.com/manaryuujin
+    - platform: YouTube
+      url: https://www.youtube.com/@manaryuujin
+    - platform: TikTok
+      url: https://www.tiktok.com/@mana_drg
+    - platform: Instagram
+      url: https://www.instagram.com/manaryuujin/
 
 masakifujiwara:
-  name: MasaFujiwara
-  country: '?'
+  name: Masaki Fujiwara
+  country: CAN
   socials:
     - platform: Twitch
       url: https://www.twitch.tv/masakifujiwara
+    - platform: Twitter
+      url: https://twitter.com/masakifujiwa_ch
+    - platform: TikTok
+      url: https://www.tiktok.com/@masakifujiwara_ch
 
 mommysillica:
   name: MommySillica
@@ -580,6 +728,16 @@ mommysillica:
   socials:
     - platform: Twitch
       url: https://www.twitch.tv/mommysillica
+    - platform: Twitter
+      url: https://twitter.com/MissSillica
+    - platform: YouTube
+      url: https://www.youtube.com/channel/UCAUdSYggqzAn-yonZaCx46w
+    - platform: TikTok
+      url: https://www.tiktok.com/@misssillica
+    - platform: Instagram
+      url: https://www.instagram.com/misssillica
+    - platform: Links
+      url: https://sillica.carrd.co/
 
 narcos_furry:
   name: Narcos_Furry
@@ -587,6 +745,8 @@ narcos_furry:
   socials:
     - platform: Twitch
       url: https://www.twitch.tv/narcos_furry
+    - platform: Instagram
+      url: https://www.instagram.com/narcos_furry_twitch
 
 nia_c:
   name: Nia_C
@@ -594,6 +754,10 @@ nia_c:
   socials:
     - platform: Twitch
       url: https://www.twitch.tv/nia_c
+    - platform: YouTube
+      url: https://www.youtube.com/channel/UCIEK4H3q-VcdQU_i9UBXcXg?sub_confirmation=1
+    - platform: TikTok
+      url: https://www.tiktok.com/@niatwitch
 
 nisumi:
   name: Nisumi
@@ -601,6 +765,10 @@ nisumi:
   socials:
     - platform: Twitch
       url: https://www.twitch.tv/nisumi
+    - platform: Twitter
+      url: https://twitter.com/Nisumi_Art
+    - platform: Links
+      url: https://nisumii.carrd.co/
 
 peachypiwie:
   name: PeachyPiwie
@@ -608,20 +776,36 @@ peachypiwie:
   socials:
     - platform: Twitch
       url: https://www.twitch.tv/peachypiwie
+    - platform: YouTube
+      url: https://www.youtube.com/@PeachyPiwie
 
 perceval_robin:
   name: Perceval Robin
-  country: '?'
+  country: FRA
   socials:
     - platform: Twitch
       url: https://www.twitch.tv/perceval_robin
+    - platform: Bluesky
+      url: https://bsky.app/profile/percevalrobin.bsky.social
+    - platform: Twitter
+      url: https://twitter.com/Perceval_Robin
+    - platform: Instagram
+      url: https://www.instagram.com/perceval_robin
+    - platform: Links
+      url: https://percevalrobin.carrd.co/
 
 pheden:
   name: Pheden
-  country: '?'
+  country: BEL
   socials:
     - platform: Twitch
       url: https://www.twitch.tv/pheden
+    - platform: Twitter
+      url: https://twitter.com/PhedenPossum
+    - platform: YouTube
+      url: https://www.youtube.com/@phedenvod
+    - platform: TikTok
+      url: https://www.tiktok.com/@phedenpossum
 
 plivecrocodile:
   name: Plivecrocodile
@@ -632,38 +816,90 @@ plivecrocodile:
 
 pocat:
   name: Pocat
-  country: '?'
+  country: SGP
   socials:
     - platform: Twitch
       url: https://www.twitch.tv/pocat
+    - platform: Bluesky
+      url: https://bsky.app/profile/pocat.live
+    - platform: Twitter
+      url:
+    - platform: Mastodon
+      url:
+    - platform: YouTube
+      url: https://www.youtube.com/@pocatTF
+    - platform: TikTok
+      url: https://www.tiktok.com/@pocat_
+    - platform: Instagram
+      url:
+    - platform: Website
+      url:
+    - platform: Links
+      url:
 
 ponokichan:
-  name: PonoKichan
-  country: '?'
+  name: Ponoki Chan
+  country: FRA
   socials:
     - platform: Twitch
       url: https://www.twitch.tv/ponokichan
+    - platform: Twitter
+      url: https://twitter.com/Ponoki_Chan
+    - platform: YouTube
+      url: https://www.youtube.com/@ponoki
+    - platform: TikTok
+      url: https://www.tiktok.com/@ponokichan
+    - platform: Instagram
+      url: https://www.instagram.com/ponokichan/
+    - platform: Website
+      url: https://www.ponoki.net/
+    - platform: Links
+      url: https://linktr.ee/ponoki
 
 ryuuna_vt:
   name: Ryuuna_VT
-  country: '?'
+  country: FRA
   socials:
     - platform: Twitch
       url: https://www.twitch.tv/ryuuna_vt
+    - platform: Twitter
+      url: https://x.com/ryuuna_vt
+    - platform: YouTube
+      url: https://www.youtube.com/@ryuuna_vt
+    - platform: TikTok
+      url: https://www.tiktok.com/@ryuuna_vt
+    - platform: Website
+      url: https://ryuuna-miokatsu.com/
 
 shalinka:
   name: Shalinka
-  country: '?'
+  country: FRA
   socials:
     - platform: Twitch
       url: https://www.twitch.tv/shalinka
+    - platform: Bluesky
+      url: https://bsky.app/profile/shalinka.bsky.social
+    - platform: Twitter
+      url: https://twitter.com/shalinkarts
+    - platform: Facebook
+      url: https://www.facebook.com/Shalinkarts
+    - platform: Instagram
+      url: https://www.instagram.com/shalinkarts/
+    - platform: Website
+      url: https://shalinka.net/
+    - platform: Links
+      url: https://shalinka.carrd.co/
 
 shiholitchi:
   name: Shiholitchi
-  country: '?'
+  country: FRA
   socials:
     - platform: Twitch
       url: https://www.twitch.tv/shiholitchi
+    - platform: Twitter
+      url: https://twitter.com/ShihoLitchi
+    - platform: TikTok
+      url: https://www.tiktok.com/@shiholitchi
 
 sol_hms:
   name: Sol_Hms
@@ -671,20 +907,38 @@ sol_hms:
   socials:
     - platform: Twitch
       url: https://www.twitch.tv/sol_hms
+    - platform: Twitter
+      url: https://twitter.com/sol_hms
+    - platform: YouTube
+      url: https://www.youtube.com/@solhmsYT
+    - platform: TikTok
+      url: https://www.tiktok.com/@sol_hms
 
 spica_stellaris:
   name: Spica Stellaris
-  country: '?'
+  country: FRA
   socials:
     - platform: Twitch
       url: https://www.twitch.tv/spica_stellaris
+    - platform: Twitter
+      url: https://twitter.com/spica_stellaris
+    - platform: TikTok
+      url: https://www.tiktok.com/@spica_stellaris
 
 sumashu:
   name: SumaShu
-  country: '?'
+  country: FRA
   socials:
     - platform: Twitch
       url: https://www.twitch.tv/sumashu
+    - platform: Twitter
+      url: https://twitter.com/Sumashu
+    - platform: YouTube
+      url: https://www.youtube.com/@Sumashu
+    - platform: TikTok
+      url: https://www.tiktok.com/@sumashuyt
+    - platform: Instagram
+      url: https://www.instagram.com/sumashuyt/
 
 takudev:
   name: TakuDev
@@ -692,6 +946,18 @@ takudev:
   socials:
     - platform: Twitch
       url: https://www.twitch.tv/takudev
+    - platform: Twitter
+      url: https://twitter.com/jojo58fr
+    - platform: YouTube
+      url: https://www.youtube.com/channel/@takudev
+    - platform: TikTok
+      url: https://www.tiktok.com/@takudev
+    - platform: Instagram
+      url: https://www.instagram.com/joachim.miens
+    - platform: GitHub
+      url: http://github.com/jojo58fr
+    - platform: Website
+      url: https://www.takudev.com/
 
 the_skinwalkers:
   name: The_SkinWalkers
@@ -699,13 +965,27 @@ the_skinwalkers:
   socials:
     - platform: Twitch
       url: https://www.twitch.tv/the_skinwalkers
+    - platform: Bluesky
+      url: https://bsky.app/profile/theskinwalkers.bsky.social
+    - platform: Twitter
+      url: https://twitter.com/The_Skinwalkers
+    - platform: YouTube
+      url: https://www.youtube.com/channel/UCKfXf0mDgejAWsXIsfuj7og
+    - platform: TikTok
+      url: https://www.tiktok.com/@skinwalkers_vtuber
 
 the_turboyoyo:
   name: The_TurboYoyo
-  country: '?'
+  country: FRA
   socials:
     - platform: Twitch
       url: https://www.twitch.tv/the_turboyoyo
+    - platform: Twitter
+      url: https://twitter.com/The_Turboyoyo
+    - platform: YouTube
+      url: https://www.youtube.com/channel/UCc5XHroRbnTkOH1NvanamyA
+    - platform: TikTok
+      url: https://www.tiktok.com/@_theturboyoyo
 
 volpoune:
   name: Volpoune
@@ -713,13 +993,27 @@ volpoune:
   socials:
     - platform: Twitch
       url: https://www.twitch.tv/volpoune
+    - platform: Instagram
+      url: https://www.instagram.com/volpoune/
 
 yhusky_kun:
   name: YHusky_Kun
-  country: '?'
+  country: FRA
   socials:
     - platform: Twitch
       url: https://www.twitch.tv/yhusky_kun
+    - platform: Bluesky
+      url: https://bsky.app/profile/yhusky.bsky.social
+    - platform: Twitter
+      url: https://twitter.com/yhusky_kun
+    - platform: YouTube
+      url: https://www.youtube.com/@yhusky_kun
+    - platform: TikTok
+      url: https://www.tiktok.com/@yhusky_kun
+    - platform: Instagram
+      url: https://www.instagram.com/yhusky_kun
+    - platform: Links
+      url: https://yhusky.carrd.co/
 
 yuiicky:
   name: Yuiicky
@@ -727,3 +1021,9 @@ yuiicky:
   socials:
     - platform: Twitch
       url: https://www.twitch.tv/yuiicky
+    - platform: Twitter
+      url: https://twitter.com/Yuiicky
+    - platform: Instagram
+      url: https://www.instagram.com/yuiicky/?theme=dark
+    - platform: Links
+      url: https://yuicky.straw.page/


### PR DESCRIPTION
Update 2025 streamers:
- Add `blaqkcat` in list

Update streamers socials:
- Add social links for many streamers

Update 2025 pages:
- Update streamers count
- Update wording in 2025 index page

Update `CountryFlag` component:
- Add `Singapore` country
- Refactor code

Update `SocialPlatformIcon` component:
- Add `Bluesky` platform
- Add `Facebook` platform
- Add `GitHub` platform
- Add `Instagram` platform
- Add `Links` platform
- Add `Mastodon` platform
- Add `Patreon` platform
- Add `Telegram` platform
- Add `Tumblr` platform
- Refactor code

Update `StreamersTable` component:
- Refactor code
- Add the list of social platforms to display